### PR TITLE
FIX : 목록 조회시 목록의 마지막 Id 조회 누락

### DIFF
--- a/src/domain/post/post.response.dto.ts
+++ b/src/domain/post/post.response.dto.ts
@@ -5,8 +5,12 @@ export class PostsResponse {
     this.contents = posts?.map((post) => {
       return { ...post, ...post.dateColumns };
     });
+    if (posts.length > 0) {
+      this.beforeLastId = posts[posts.length - 1].id;
+    }
   }
 
+  beforeLastId: number;
   contents: {
     id: number;
     author: string;

--- a/src/test/domain/post/post.controller.spec.ts
+++ b/src/test/domain/post/post.controller.spec.ts
@@ -272,7 +272,14 @@ describe('PostController', () => {
             );
           }),
         ).toBeTruthy();
-        return expect(res.body.contents.length > 0).toBeTruthy();
+        await expect(res.body.contents.length > 0).toBeTruthy();
+
+        const minId = Math.min.apply(
+          null,
+          res.body.contents.map((post) => post.id),
+        );
+
+        await expect(res.body.beforeLastId).toEqual(minId);
       });
 
       test('이전 조회 목록의 마지막 게시글 이후의 목록 중에서 검색어에 해당하는 게시글 목록 조회', async () => {
@@ -298,7 +305,14 @@ describe('PostController', () => {
             );
           }),
         ).toBeTruthy();
-        return expect(res.body.contents.length > 0).toBeTruthy();
+        await expect(res.body.contents.length > 0).toBeTruthy();
+
+        const minId = Math.min.apply(
+          null,
+          res.body.contents.map((post) => post.id),
+        );
+
+        await expect(res.body.beforeLastId).toEqual(minId);
       });
 
       test('검색조건 없이 게시글 목록 조회', async () => {
@@ -306,7 +320,14 @@ describe('PostController', () => {
           .get('/api/posts')
           .expect(200);
 
-        return expect(res.body.contents.length).toEqual(20);
+        await expect(res.body.contents.length).toEqual(20);
+
+        const minId = Math.min.apply(
+          null,
+          res.body.contents.map((post) => post.id),
+        );
+
+        await expect(res.body.beforeLastId).toEqual(minId);
       });
     });
   });


### PR DESCRIPTION
# 변경사항
게시글 목록 조회 데이터에 목록중 마지막 게시글의 id 값 추가