### PR TITLE
Style : 게시글 조회 결과의 변수명을 content 에서 post 로 변경

### DIFF
--- a/src/domain/post/post.response.dto.ts
+++ b/src/domain/post/post.response.dto.ts
@@ -2,7 +2,7 @@ import { Post } from './post.entity';
 
 export class PostsResponse {
   constructor(posts: Post[]) {
-    this.contents = posts?.map((post) => {
+    this.posts = posts?.map((post) => {
       return { ...post, ...post.dateColumns };
     });
     if (posts.length > 0) {
@@ -11,7 +11,7 @@ export class PostsResponse {
   }
 
   beforeLastId: number;
-  contents: {
+  posts: {
     id: number;
     author: string;
     title: string;
@@ -21,10 +21,10 @@ export class PostsResponse {
 
 export class PostResponse {
   constructor(post: Post) {
-    this.content = { ...post, ...post.dateColumns };
+    this.post = { ...post, ...post.dateColumns };
   }
 
-  content: {
+  post: {
     id: number;
     author: string;
     title: string;

--- a/src/test/domain/post/post.controller.spec.ts
+++ b/src/test/domain/post/post.controller.spec.ts
@@ -251,9 +251,9 @@ describe('PostController', () => {
           .expect(200);
 
         await expect(
-          res.body.contents.every((post) => post.id < beforeLastId),
+          res.body.posts.every((post) => post.id < beforeLastId),
         ).toBeTruthy();
-        return expect(res.body.contents.length > 0).toBeTruthy();
+        return expect(res.body.posts.length > 0).toBeTruthy();
       });
 
       test('검색어에 해당하는 게시글 목록 조회', async () => {
@@ -263,7 +263,7 @@ describe('PostController', () => {
           .expect(200);
 
         await expect(
-          res.body.contents.every((post) => {
+          res.body.posts.every((post) => {
             return (
               post.title.indexOf('게시글') ||
               post.title.indexOf('2') ||
@@ -272,11 +272,11 @@ describe('PostController', () => {
             );
           }),
         ).toBeTruthy();
-        await expect(res.body.contents.length > 0).toBeTruthy();
+        await expect(res.body.posts.length > 0).toBeTruthy();
 
         const minId = Math.min.apply(
           null,
-          res.body.contents.map((post) => post.id),
+          res.body.posts.map((post) => post.id),
         );
 
         await expect(res.body.beforeLastId).toEqual(minId);
@@ -295,7 +295,7 @@ describe('PostController', () => {
           .expect(200);
 
         await expect(
-          res.body.contents.every((post) => {
+          res.body.posts.every((post) => {
             return (
               post.id < beforeLastId &&
               (post.title.indexOf('게시글') ||
@@ -305,11 +305,11 @@ describe('PostController', () => {
             );
           }),
         ).toBeTruthy();
-        await expect(res.body.contents.length > 0).toBeTruthy();
+        await expect(res.body.posts.length > 0).toBeTruthy();
 
         const minId = Math.min.apply(
           null,
-          res.body.contents.map((post) => post.id),
+          res.body.posts.map((post) => post.id),
         );
 
         await expect(res.body.beforeLastId).toEqual(minId);
@@ -320,11 +320,11 @@ describe('PostController', () => {
           .get('/api/posts')
           .expect(200);
 
-        await expect(res.body.contents.length).toEqual(20);
+        await expect(res.body.posts.length).toEqual(20);
 
         const minId = Math.min.apply(
           null,
-          res.body.contents.map((post) => post.id),
+          res.body.posts.map((post) => post.id),
         );
 
         await expect(res.body.beforeLastId).toEqual(minId);
@@ -376,7 +376,7 @@ describe('PostController', () => {
         .get(`/api/posts/${id}`)
         .expect(200);
 
-      return expect(res.body.content.id).toEqual(id);
+      return expect(res.body.post.id).toEqual(id);
     });
   });
 


### PR DESCRIPTION
# 변경사항
게시글 조회 결과의 변수명을 content 에서 post 로 변경
- 게시글 본문의 변수명인 content 와 의미를 다르게 두기 위해 게시글을 의미하는 post 로 변경